### PR TITLE
FIX "lua error: Command not implemented in Lua qsfunctions module: getNumCandles"

### DIFF
--- a/QuikPy.py
+++ b/QuikPy.py
@@ -415,7 +415,7 @@ class QuikPy(metaclass=Singleton):  # Singleton класс
 
     def GetNumCandles(self, Tag, TransId=0):  # 2
         """Кол-во свечей по тэгу"""
-        return self.ProcessRequest({'data': Tag, 'id': TransId, 'cmd': 'getNumCandles', 't': ''})
+        return self.ProcessRequest({'data': Tag, 'id': TransId, 'cmd': 'get_num_candles', 't': ''})
 
     # getCandlesByIndex - 3. Информация о свечках (реализовано в get_candles)
     # CreateDataSource - 4. Создание источника данных c функциями: (реализовано в get_candles_from_data_source)


### PR DESCRIPTION
Исправление ошибки "lua error: Command not implemented in Lua qsfunctions module: getNumCandles"при вызове метода qpProvider.GetNumCandles. 

В текущей реализации не корреткно указан параметр "cmd" для вызова функции в qsfunctions.lua, возвращающей количество свечей по тегу - 'getNumCandles' вместо 'get_num_candles'.